### PR TITLE
[TASK] Split up Utility class in several classes

### DIFF
--- a/Classes/Command/CheckIntegrityCommand.php
+++ b/Classes/Command/CheckIntegrityCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace B13\Typo3Composerize\Command;
 
 use B13\Typo3Composerize\Utilities\ComposerConvertUtility;
+use B13\Typo3Composerize\Utilities\ComposerManifestCreator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,7 +24,7 @@ class CheckIntegrityCommand extends BaseComposerizeCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        list($extensions, $docRoot, $folders) = $this->getArguments($input);
+        [$extensions, $docRoot, $folders] = $this->getArguments($input);
 
         $utility = new ComposerConvertUtility($docRoot, $folders);
         $extensions = $utility->validateExtensions($extensions);
@@ -34,7 +35,7 @@ class CheckIntegrityCommand extends BaseComposerizeCommand
                 'ext-key' => $extension['ext-key'],
                 'composer-json' => $extension['composer-json'] ? '<fg=green>yes</>' : '<fg=red>no</>',
                 'extra-extension-key' => $extension['extra-extension-key'] ? '<fg=green>yes</>' : '<fg=red>no</>',
-                'package-name' => $extension['package-name'] ? $extension['package-name'] : '<fg=red>Preview: ' . ComposerConvertUtility::convertToPackageName($extension['ext-key']) . '</>',
+                'package-name' => $extension['package-name'] ? $extension['package-name'] : '<fg=red>Preview: ' . ComposerManifestCreator::getFallbackPackageNameFromExtensionKey($extension['ext-key']) . '</>',
             ];
         }
 

--- a/Classes/Utilities/ComposerManifestCreator.php
+++ b/Classes/Utilities/ComposerManifestCreator.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+namespace B13\Typo3Composerize\Utilities;
+
+/**
+ * Creates a composer.json out of the extension key and the ext_emconf.php data
+ */
+class ComposerManifestCreator
+{
+    protected ExtensionKeyMap $extensionKeyMap;
+    const FALLBACK_VENDOR = 'typo3-local';
+
+    public function __construct(ExtensionKeyMap $map = null)
+    {
+        $this->extensionKeyMap = $map ?? new ExtensionKeyMap();
+    }
+
+    public function createComposerManifest(string $extensionKey, array $emConf): array
+    {
+        $constraints = ['depends', 'suggests', 'conflicts'];
+        foreach ($constraints as $constraint) {
+            unset($$constraint);
+            if (!empty($emConf['constraints'][$constraint])) {
+                foreach ($emConf['constraints'][$constraint] as $key => $version) {
+                    [$currentKey, $currentVersion] = $this->convertConstraint($key, $version);
+                    $$constraint[$currentKey] = $currentVersion;
+                }
+            }
+        }
+
+        return [
+            'name' => $this->getPackageName($extensionKey),
+            'description' => $emConf['title'] . ' - ' . ($emConf['description'] ?? ''),
+            'license' => 'GPL-2.0-or-later',
+            'type' => 'typo3-cms-extension',
+            'authors' => [
+                [
+                    'name' => $emConf['author'] ?? '',
+                    'email' => $emConf['author_email'] ?? 'no-email@given.com',
+                ]
+            ],
+            'require' => $depends ?? (object)null,
+            'suggest' => $suggests ?? (object)null,
+            'conflict' => $conflicts ?? (object)null,
+            'extra' => [
+                'typo3/cms' => [
+                    'extension-key' => $extensionKey,
+                ]
+            ],
+            'version' => 'dev-local',
+            'autoload' => [
+                'classmap' => ['*'],
+            ]
+        ];
+    }
+
+
+    /**
+     * @param string $extKey
+     * @param string $versions
+     * @return array
+     */
+    public function convertConstraint(string $extKey, string $versions): array
+    {
+        $packageName = $this->getPackageName($extKey);
+
+        // Set * if package is empty or a local package
+        if (empty($versions) || preg_match('/^' . self::FALLBACK_VENDOR . '\/(.*)/', $packageName)) {
+            return [$packageName, '*'];
+        }
+
+        // TODO: Good or Bad? ... alternative would be `*` on all
+        $versionNumbers = [];
+        foreach (explode('-', $versions) as $version) {
+            $explodedVersion = explode('.', trim($version));
+            $versionNumbers[] = $explodedVersion[0];
+        }
+
+        $constraint = [];
+        if (count($versionNumbers) === 2) {
+            foreach (range($versionNumbers[0], $versionNumbers[1]) as $version) {
+                $constraint[] = '~' . $version;
+            }
+        } else {
+            $constraint[] = '~' . $versionNumbers[0];
+        }
+
+        return [$packageName, implode(' || ', $constraint)];
+    }
+
+    /**
+     * Return the composer package name for the extension key
+     * First checks the database, then creates a fallback
+     *
+     * @param string $extKey
+     * @return false|mixed
+     */
+    public function getPackageName(string $extKey)
+    {
+        $packageName = $this->extensionKeyMap->resolvePackageNameFromExtensionKey($extKey);
+        return $packageName ?? self::getFallbackPackageNameFromExtensionKey($extKey);
+    }
+
+    public static function getFallbackPackageNameFromExtensionKey(string $extKey): string
+    {
+        return self::FALLBACK_VENDOR . '/' . str_replace('_', '-', $extKey);
+    }
+}

--- a/Classes/Utilities/ExtensionKeyMap.php
+++ b/Classes/Utilities/ExtensionKeyMap.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace B13\Typo3Composerize\Utilities;
+
+/**
+ * Class which acts like a database for converting a single extension key into a composer-package name.
+ * If none found, returns null.
+ */
+class ExtensionKeyMap
+{
+    // TODO: Due to performance issues not used atm, loading only a local file see $this->terComposerMap
+    //const TER_URL = 'https://extensions.typo3.org/index.php?eID=ter_fe2:extension&action=findAllWithValidComposerName';
+
+    protected array $terComposerMap = [];
+
+    const CORE_EXTENSIONS = [
+        'php' => 'php',
+        'typo3' => 'typo3/cms-core',
+        'extbase' => 'typo3/cms-extbase',
+        'belog' => 'typo3/cms-belog',
+        'form' => 'typo3/cms-form',
+        'install' => 'typo3/cms-install',
+        'core' => 'typo3/cms-core',
+        'cms' => 'typo3/cms-core',
+        'frontend' => 'typo3/cms-frontend',
+        'felogin' => 'typo3/cms-felogin',
+        'setup' => 'typo3/cms-setup',
+        'impexp' => 'typo3/cms-impexp',
+        'fluid_styled_content' => 'typo3/cms-fluid-styled-content',
+        'backend' => 'typo3/cms-backend',
+        'fluid' => 'typo3/cms-fluid',
+        'tstemplate' => 'typo3/cms-tstemplate',
+        'info' => 'typo3/cms-info',
+        'dashboard' => 'typo3/cms-dashboard',
+        'extensionmanager' => 'typo3/cms-extensionmanager',
+        'filelist' => 'typo3/cms-filelist',
+        't3editor' => 'typo3/cms-t3editor',
+        'lowlevel' => 'typo3/cms-lowlevel',
+        'beuser' => 'typo3/cms-beuser',
+        'rte_ckeditor' => 'typo3/cms-rte-ckeditor',
+        'seo' => 'typo3/cms-seo',
+        'viewpage' => 'typo3/cms-viewpage',
+        'sys_note' => 'typo3/cms-sys-note',
+        'recordlist' => 'typo3/cms-recordlist',
+        'workspaces' => 'typo3/cms-workspaces',
+        'adminpanel' => 'typo3/cms-adminpanel',
+        'filemetadata' => 'typo3/cms-filemetadata',
+        'indexed_search' => 'typo3/cms-indexed-search',
+        'linkvalidator' => 'typo3/cms-linkvalidator',
+        'opendocs' => 'typo3/cms-opendocs',
+        'recycler' => 'typo3/cms-recycler',
+        'redirects' => 'typo3/cms-redirects',
+        'reports' => 'typo3/cms-reports',
+        'scheduler' => 'typo3/cms-scheduler',
+    ];
+
+    public function __construct(array $mapData = null)
+    {
+        if (is_array($mapData)) {
+            $this->terComposerMap = $mapData;
+        } else {
+            $terComposerMap = json_decode(file_get_contents(__DIR__ . '/../../Static/typo3-ter-composer-map.json'), true);
+            $this->terComposerMap = (array)($terComposerMap['data'] ?? []);
+        }
+    }
+
+    public function resolvePackageNameFromExtensionKey(string $extKey): ?string
+    {
+        if (!empty($this->terComposerMap['data'][$extKey]['composer_name'])) {
+            return $this->terComposerMap['data'][$extKey]['composer_name'];
+        }
+
+        if (!empty(self::CORE_EXTENSIONS[$extKey])) {
+            return self::CORE_EXTENSIONS[$extKey];
+        }
+        return null;
+    }
+}

--- a/Tests/Fixtures/sample_extension/composer.json
+++ b/Tests/Fixtures/sample_extension/composer.json
@@ -1,19 +1,20 @@
 {
-  "name": "b13/test-package",
-  "type": "typo3-cms-extension",
-  "description": "Sample composer.json for running tests",
-  "license": "GPL-2.0-or-later",
-  "authors": [
-    {
-      "name": "Sample name",
-      "role": "Developer",
-      "homepage": "https://b13.com"
+    "name": "b13/test-package",
+    "type": "typo3-cms-extension",
+    "description": "Sample composer.json for running tests",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Sample name",
+            "role": "Developer",
+            "homepage": "https://b13.com"
+        }
+    ],
+    "require": [],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "11.2.x-dev"
+        },
+        "typo3/cms": []
     }
-  ],
-  "require": {},
-  "extra": {
-    "branch-alias": {
-      "dev-master": "11.2.x-dev"
-    }
-  }
 }

--- a/Tests/Unit/Utilities/ComposerConvertUtilityTest.php
+++ b/Tests/Unit/Utilities/ComposerConvertUtilityTest.php
@@ -67,85 +67,11 @@ final class ComposerConvertUtilityTest extends TestCase
         self::assertContains('Classes/SampleClass.php', $composerJson['autoload']['classmap']);
     }
 
-    public function testConvertToPackageName(): void
-    {
-        self::assertSame(
-            'typo3-local/my-extension',
-            ComposerConvertUtility::convertToPackageName('my_extension')
-        );
-    }
-
     public function testSetExtensionKey(): void
     {
         $this->utility->setExtensionKey($this->extensionPath, 'sample_extension', self::UPDATED_JSON_FILE);
 
         self::assertFileEquals($this->extensionPath . '/composer_expected.json', $this->extensionPath . '/' . self::UPDATED_JSON_FILE);
-    }
-
-    public function testGetPackageName(): void
-    {
-        // Test to get composer package name from TER
-        self::assertSame(
-            'georgringer/news',
-            $this->utility->getPackageName('news')
-        );
-
-        // Test to get composer package name from map
-        self::assertSame(
-            'typo3/cms-core',
-            $this->utility->getPackageName('typo3')
-        );
-
-        // Test specific case for defined php version
-        self::assertSame(
-            'php',
-            $this->utility->getPackageName('php')
-        );
-
-        // Test case if package name neither found on TER nor in mapping
-        self::assertSame(
-            'typo3-local/not-existing-extension',
-            $this->utility->getPackageName('not_existing_extension')
-        );
-    }
-
-    public function testConvertConstraint(): void
-    {
-        // Test extension not existing on packagist, force version *
-        self::assertEquals(
-            [
-            0 => 'typo3-local/naw-securedl',
-            1 => '*',
-        ],
-            $this->utility->convertConstraint('naw_securedl', '1')
-        );
-
-        // Test empty
-        self::assertEquals(
-            [
-                0 => 'typo3/cms-core',
-                1 => '*',
-            ],
-            $this->utility->convertConstraint('typo3', '')
-        );
-
-        // Test range between multiple versions
-        self::assertEquals(
-            [
-                0 => 'typo3/cms-core',
-                1 => '~7 || ~8 || ~9',
-            ],
-            $this->utility->convertConstraint('typo3', '7.0.0 - 9.4')
-        );
-
-        // Test single version
-        self::assertEquals(
-            [
-                0 => 'typo3/cms-core',
-                1 => '~7',
-            ],
-            $this->utility->convertConstraint('typo3', '7.0.0')
-        );
     }
 
     public function testLoadEmConf(): void

--- a/Tests/Unit/Utilities/ComposerManifestCreatorTest.php
+++ b/Tests/Unit/Utilities/ComposerManifestCreatorTest.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace B13\Typo3Composerize\Tests\Unit\Command;
+
+
+use B13\Typo3Composerize\Utilities\ComposerManifestCreator;
+use PHPUnit\Framework\TestCase;
+
+class ComposerManifestCreatorTest extends TestCase
+{
+
+    public function testConvertToPackageName(): void
+    {
+        self::assertSame(
+            'typo3-local/my-extension',
+            ComposerManifestCreator::getFallbackPackageNameFromExtensionKey('my_extension')
+        );
+    }
+
+    public function testGetPackageName(): void
+    {
+        $subject = new ComposerManifestCreator();
+        // Test to get composer package name from TER
+        self::assertSame(
+            'georgringer/news',
+            $subject->getPackageName('news')
+        );
+
+        // Test to get composer package name from map
+        self::assertSame(
+            'typo3/cms-core',
+            $subject->getPackageName('typo3')
+        );
+
+        // Test specific case for defined php version
+        self::assertSame(
+            'php',
+            $subject->getPackageName('php')
+        );
+
+        // Test case if package name neither found on TER nor in mapping
+        self::assertSame(
+            'typo3-local/not-existing-extension',
+            $subject->getPackageName('not_existing_extension')
+        );
+    }
+
+    public function testConvertConstraint(): void
+    {
+        $subject = new ComposerManifestCreator();
+        // Test extension not existing on packagist, force version *
+        self::assertEquals(
+            [
+                0 => 'typo3-local/naw-securedl',
+                1 => '*',
+            ],
+            $subject->convertConstraint('naw_securedl', '1')
+        );
+
+        // Test empty
+        self::assertEquals(
+            [
+                0 => 'typo3/cms-core',
+                1 => '*',
+            ],
+            $subject->convertConstraint('typo3', '')
+        );
+
+        // Test range between multiple versions
+        self::assertEquals(
+            [
+                0 => 'typo3/cms-core',
+                1 => '~7 || ~8 || ~9',
+            ],
+            $this->utility->convertConstraint('typo3', '7.0.0 - 9.4')
+        );
+
+        // Test single version
+        self::assertEquals(
+            [
+                0 => 'typo3/cms-core',
+                1 => '~7',
+            ],
+            $this->utility->convertConstraint('typo3', '7.0.0')
+        );
+    }
+}


### PR DESCRIPTION
This change splits up the Utility class
so the Converter can be used without having
any filesystem access in a different environment.